### PR TITLE
Success build with trunk openwrt toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 #
 
 kerndir=kernel/linux-2.6.36
-cross=../../toolchain/hndtools-arm-linux-2.6.36-uclibc-4.5.3/bin/arm-brcm-linux-uclibcgnueabi-
+cross=../../toolchain/toolchain-arm_cortex-a9+vfpv3_gcc-4.8-linaro_uClibc-0.9.33.2_eabi/bin/arm-openwrt-linux-uclibcgnueabi-
 
-STRIP=toolchain/hndtools-arm-linux-2.6.36-uclibc-4.5.3/bin/arm-brcm-linux-uclibcgnueabi-strip 
+STRIP=toolchain/toolchain-arm_cortex-a9+vfpv3_gcc-4.8-linaro_uClibc-0.9.33.2_eabi/bin/arm-openwrt-linux-uclibcgnueabi-strip 
 
 NCPUS:=1
 OS:=$(shell uname -s)
@@ -14,7 +14,8 @@ ifeq ($(OS),Linux)
   NCPUS:=$(shell grep -c ^processor /proc/cpuinfo)
 endif
 
-export LD_LIBRARY_PATH=$(shell pwd)/toolchain/hndtools-arm-linux-2.6.36-uclibc-4.5.3/lib/
+export LD_LIBRARY_PATH=$(shell pwd)/toolchain/toolchain-arm_cortex-a9+vfpv3_gcc-4.8-linaro_uClibc-0.9.33.2_eabi/lib/
+export STAGING_DIR=$(shell pwd)/staging_dir/
 
 all: vmlinuz rootfs
 	@echo '-----------------------------------------------------'

--- a/kernel/linux-2.6.36/drivers/net/et/Makefile
+++ b/kernel/linux-2.6.36/drivers/net/et/Makefile
@@ -17,7 +17,7 @@
 #
 # $Id: Makefile,v 1.5 2010-12-07 04:47:36 $
 #
-EXTRA_CFLAGS	+= -DDMA -Werror -Idrivers/net/et/
+EXTRA_CFLAGS	+= -DDMA -Idrivers/net/et/
 
 obj-$(CONFIG_ET) := et.o
 


### PR DESCRIPTION
Hello.
I've successfully build with source openwrt toolchain (from barrier breaker).
Just an option for you :)

(openwrt is from http://git.openwrt.org/openwrt.git)
Then set target system as Broadcom BCM47xx/53xx wirh ARM, the compiler to the latest 4.8.x linaro and uclibc to 0.9.33.2
After building just make a symlink from staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-4.8-linaro_uClibc-0.9.33.2_eabi of openwrt into toolchain of your project.

Have a question to you:
I've tried to build and run latest kernel (3.14.18), but it stucks  just after loading (after CFE runs loaded image from 0x00008000 nothing else happens).
Do you have any customization to the sources of 2.6.36, specific to the M1D?
(Just try to guess the reason of the stuck and resolve it).
